### PR TITLE
Fix alignment issue for unicode

### DIFF
--- a/content.go
+++ b/content.go
@@ -2,9 +2,9 @@ package simpletable
 
 import (
 	"fmt"
+	"github.com/mattn/go-runewidth"
 	"regexp"
 	"strings"
-	"unicode/utf8"
 )
 
 // stripAnsiEscapeRegexp is a regular expression to clean ANSI Control sequences
@@ -115,5 +115,5 @@ func stripAnsiEscape(s string) string {
 
 // realWidth returns real string length (without ANSI escape sequences)
 func realLength(s string) int {
-	return utf8.RuneCountInString(stripAnsiEscape(s))
+	return runewidth.StringWidth(stripAnsiEscape(s))
 }


### PR DESCRIPTION
Fix #6.

For CJK characters, when displayed in terminal, they take more that one position. For whatever reason,  what is returned by utf8.RuneCountInString is not expected. 

this patch uses https://github.com/mattn/go-runewidth to get the correct content length of the cell.  see https://play.golang.org/p/2xDzwKjK7H8

