### PR TITLE
Add CompactClassic style

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This package allows to generate and display ascii tables in the terminal, f.e.:
 
 There are the following key features:
 * **Declarative style.** _Have to write more code, and hell with it._
-* **Styling.** _With 6 predefined styles: MySql-like (default), compact, compact lite, markdown, 
+* **Styling.** _With 7 predefined styles: MySql-like (default), compact, compact lite, compact classic, markdown, 
   rounded and unicode. And you can change it._
 * **Header and footer.** _Separated from table body._
 * **Multiline cells support.** _See [_example/main.go/_example/04-multiline/main.go](https://github.com/alexeyco/simpletable/blob/master/_example/04-multiline/main.go) for example._

--- a/_example/01-styles-demo/main.go
+++ b/_example/01-styles-demo/main.go
@@ -21,12 +21,13 @@ var (
 	}
 
 	styles = map[string]*simpletable.Style{
-		"Default style":      simpletable.StyleDefault,
-		"Compact style":      simpletable.StyleCompact,
-		"Compact Lite style": simpletable.StyleCompactLite,
-		"Markdown style":     simpletable.StyleMarkdown,
-		"Rounded style":      simpletable.StyleRounded,
-		"Unicode style":      simpletable.StyleUnicode,
+		"Default style":         simpletable.StyleDefault,
+		"Compact style":         simpletable.StyleCompact,
+		"Compact Lite style":    simpletable.StyleCompactLite,
+		"Compact Classic style": simpletable.StyleCompactClassic,
+		"Markdown style":        simpletable.StyleMarkdown,
+		"Rounded style":         simpletable.StyleRounded,
+		"Unicode style":         simpletable.StyleUnicode,
 	}
 )
 

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -19,12 +19,13 @@ var (
 		{10, "Juan J. Kennedy", "908-910-8893", "JuanJKennedy@dayrep.com", 16},
 	}
 
-	benchStyleDefaultTable     = benchStyleTable(StyleDefault)
-	benchStyleCompactTable     = benchStyleTable(StyleCompact)
-	benchStyleCompactLiteTable = benchStyleTable(StyleCompactLite)
-	benchStyleMarkdownTable    = benchStyleTable(StyleMarkdown)
-	benchStyleRoundedTable     = benchStyleTable(StyleRounded)
-	benchStyleUnicodeTable     = benchStyleTable(StyleUnicode)
+	benchStyleDefaultTable        = benchStyleTable(StyleDefault)
+	benchStyleCompactTable        = benchStyleTable(StyleCompact)
+	benchStyleCompactLiteTable    = benchStyleTable(StyleCompactLite)
+	benchStyleCompactClassicTable = benchStyleTable(StyleCompactClassic)
+	benchStyleMarkdownTable       = benchStyleTable(StyleMarkdown)
+	benchStyleRoundedTable        = benchStyleTable(StyleRounded)
+	benchStyleUnicodeTable        = benchStyleTable(StyleUnicode)
 )
 
 func BenchmarkStyleDefault(b *testing.B) {
@@ -42,6 +43,12 @@ func BenchmarkStyleCompact(b *testing.B) {
 func BenchmarkStyleCompactLite(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = benchStyleCompactLiteTable.String()
+	}
+}
+
+func BenchmarkStyleCompactClassic(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = benchStyleCompactClassicTable.String()
 	}
 }
 

--- a/style.go
+++ b/style.go
@@ -102,6 +102,37 @@ var (
 		Cell: " ",
 	}
 
+	// StyleCompactClassic - compact classic table style:
+	//
+	//  #         NAME            TAX
+	//  1   Newton G. Goetz      $ 532.70
+	//  2   Rebecca R. Edney    $ 1423.25
+	//  3   John R. Jackson     $ 7526.12
+	//  4   Ron J. Gomes         $ 123.84
+	//  5   Penny R. Lewis      $ 3221.11
+	//              Subtotal   $ 12827.02
+	StyleCompactClassic = &Style{
+		Border: &BorderStyle{
+			TopLeft:            "",
+			Top:                "",
+			TopRight:           "",
+			Right:              "",
+			BottomRight:        "",
+			Bottom:             "",
+			BottomLeft:         "",
+			Left:               "",
+			TopIntersection:    "",
+			BottomIntersection: "",
+		},
+		Divider: &DividerStyle{
+			Left:         "",
+			Center:       "",
+			Right:        "",
+			Intersection: " ",
+		},
+		Cell: " ",
+	}
+
 	// StyleMarkdown - markdown table style:
 	//
 	// | # |       NAME       |    TAX     |

--- a/table.go
+++ b/table.go
@@ -151,12 +151,14 @@ func (t *Table) prepareRows() {
 			span: hlen,
 		}
 
-		t.rows = append(t.rows, &tblRow{
-			Cells: []cellInterface{
-				d,
-			},
-			Table: t,
-		})
+		if t.style.Divider.Center != "" {
+			t.rows = append(t.rows, &tblRow{
+				Cells: []cellInterface{
+					d,
+				},
+				Table: t,
+			})
+		}
 
 		t.dividers = append(t.dividers, d)
 	}
@@ -174,12 +176,14 @@ func (t *Table) prepareRows() {
 			span: hlen,
 		}
 
-		t.rows = append(t.rows, &tblRow{
-			Cells: []cellInterface{
-				d,
-			},
-			Table: t,
-		})
+		if t.style.Divider.Center != "" {
+			t.rows = append(t.rows, &tblRow{
+				Cells: []cellInterface{
+					d,
+				},
+				Table: t,
+			})
+		}
 
 		t.dividers = append(t.dividers, d)
 


### PR DESCRIPTION
Simple but powerful wheels.
The only regret is that there is always a divider line between header(footer) and body even with customized style.

This PR fix the problem and add a predefined style called `CompactClassic` which do not have separator line between header and body.
Inspired by `kubectl`

```go
table := st.New()
table.Header = &st.Header{
    Cells: []*st.Cell{
        {Text: "UUID", Align: st.AlignLeft},
        {Text: "NAME", Align: st.AlignLeft},
        ...
    },
}

table.Body.Cells = ...

// no footer

table.SetStyle(st.StyleCompactClassic)
fmt.Println(table.String())
```
Will output
```
UUID                                   NAME         NAMESPACE    STATUS
1aaf112f-c398-4fe8-a25b-638da8df372c   myname       my-ns        Ready
```

Very common table output style for various terminal applications. 