### PR TITLE
Make table.Body sortable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ There are the following key features:
 * **Header and footer.** _Separated from table body._
 * **Multiline cells support.** _See [_example/main.go/_example/04-multiline/main.go](https://github.com/alexeyco/simpletable/blob/master/_example/04-multiline/main.go) for example._
 * **Cell content alignment.** _Left, right or center._
+* **Sortable Body.** _Simply call `SortByField(index)` on Body to sort body cells. 
+By default, the body sorts in lexical order. 
+You can define your own compare method by `SortByFieldWithFunc(index, func)`._
 * **Row spanning.** _By analogy with the way it is done in HTML. See `Cell.Span` attribute 
   description._
 * **Fast!** _Really fast, see [_example/main.go/_example/03-benchmarks-with-others](https://github.com/alexeyco/simpletable/blob/master/_example/03-benchmarks-with-others)._
@@ -138,7 +141,7 @@ $ ls -F | grep /
 ```
 
 ## Styling
-There is 6 styles available. To view them, run [_example/main.go/01-styles-demo/main.go](https://github.com/alexeyco/simpletable/blob/master/_example/01-styles-demo/main.go):
+There is 7 styles available. To view them, run [_example/main.go/01-styles-demo/main.go](https://github.com/alexeyco/simpletable/blob/master/_example/01-styles-demo/main.go):
 ```
 $ cd $GOPATH/src/github.com/alexeyco/simpletable/_example/01-styles-demo
 $ go run main.go
@@ -163,6 +166,27 @@ c := &simpletable.Cell{
 }
 ```
 Note: by default `Span` is `1`. If you try to set it to `0`, the value will still be `1`.
+
+## Body sorting
+Using the standard `sort` package
+```go
+b := &simpletable.Body{
+	Cells:    [][]*Cell{},
+}
+
+// Will sort Cells using the first element of []*Cell in lexical order
+b.SortByField(0)
+
+// Will sort Cells using the first element of []*Cell with given Less func
+// Refer https://pkg.go.dev/sort?tab=doc
+lessFunc = func(i, j string) bool {
+    iNum, _ = strconv.Atoi(i)
+    jNum, _ = strconv.Atoi(j)
+    return iNum < jNum
+}
+b.SortByFieldWithFunc(0, lessFunc)
+```
+Note: If you are using Column spanning. You should make sure the field index used for sort is always available.
 
 ## License
 ```

--- a/contents.go
+++ b/contents.go
@@ -1,5 +1,7 @@
 package simpletable
 
+import "sort"
+
 // Header is table header
 type Header struct {
 	Cells []*Cell
@@ -7,10 +9,41 @@ type Header struct {
 
 // Body is table body
 type Body struct {
-	Cells [][]*Cell
+	Cells    [][]*Cell
+	sortBy   int // index of Cells to sort Body
+	sortFunc func(i, j string) bool
 }
 
 // Footer is table footer
 type Footer struct {
 	Cells []*Cell
+}
+
+func (b *Body) Len() int {
+	return len(b.Cells)
+}
+
+func (b *Body) Less(i, j int) bool {
+	if b.sortFunc != nil {
+		return b.sortFunc(b.Cells[i][b.sortBy].Text, b.Cells[j][b.sortBy].Text)
+	}
+	return b.Cells[i][b.sortBy].Text < b.Cells[j][b.sortBy].Text
+}
+
+func (b *Body) Swap(i, j int) {
+	b.Cells[i], b.Cells[j] = b.Cells[j], b.Cells[i]
+}
+
+// SortByField sorts table.Body by given Cells field index using lexical order
+func (b *Body) SortByField(index int) {
+	b.sortBy = index
+	b.sortFunc = nil
+	sort.Sort(b)
+}
+
+// SortByFieldWithFunc sorts table.Body by given Cells field index using Less func
+func (b *Body) SortByFieldWithFunc(index int, Less func(i, j string) bool) {
+	b.sortBy = index
+	b.sortFunc = Less
+	sort.Sort(b)
 }


### PR DESCRIPTION
This PR implements the sort interface for table.Body

You can call `table.Body.SortByField(index)` to sort Body.Cells by given field index using lexical order.
or you can call `table.Body.SortByFieldWithFunc(index, LessFunc)` to sort Cells by given field index using your own LessFunc implementation. 